### PR TITLE
Emit zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ See also `aws cloudwatch get-metric-data help`.
 cloudwatch-to-mackerel parses `Label` fields in MetricDataQuery as Mackerel's service/host which to post metrics.
 
 ```ebnf
-(* service name, host id, metric name are defined by Mackerel *)
-service = "service=" , service name ;
-host    = "host=" , host id ;
-label   = ( service | host ) , ":" , metric name ;
+(* service_name, host_id, metric_name are defined by Mackerel *)
+service = "service=" , service_name ;
+host    = "host=" , host_id ;
+option  = "emit_zero"
+label   = ( service | host ) , ":" , metric_name , { ";", option } ;
 ```
 
 ## License

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -27,53 +28,68 @@ type Option struct {
 	Session   *session.Session
 }
 
-type ParsedLabel struct {
-	Service string
-	HostID  string
-	Name    string
-	Options map[string]struct{}
+// Label represents structured label
+type Label struct {
+	Service  string
+	HostID   string
+	Name     string
+	EmitZero bool
+}
+
+func (l Label) IsService() bool {
+	return l.Service != ""
+}
+
+func (l Label) String() string {
+	var s string
+	if l.Service != "" {
+		s = fmt.Sprintf("service=%s:%s", l.Service, l.Name)
+	} else if l.HostID != "" {
+		s = fmt.Sprintf("host=%s:%s", l.HostID, l.Name)
+	}
+	if l.EmitZero {
+		s = s + ";emit_zero"
+	}
+	return s
 }
 
 // parse parses a label string as service, hostID, metric name.
-func parseLabel(label string) (*ParsedLabel, error) {
+func parseLabel(label string) (Label, error) {
 	l := strings.SplitN(label, ":", 2)
 	if len(l) != 2 {
-		return nil, errors.New("invalid label format")
+		return Label{}, errors.New("invalid label format")
 	}
 	s := strings.SplitN(l[0], "=", 2)
 	if len(s) != 2 {
-		return nil, errors.New("invalid label format")
+		return Label{}, errors.New("invalid label format")
 	}
 	t, id, name := s[0], s[1], l[1]
 	if t == "" || id == "" || name == "" {
-		return nil, errors.New("invalid label format")
+		return Label{}, errors.New("invalid label format")
 	}
-
-	options := make(map[string]struct{}, 0)
+	var parsed Label
 	if strings.Contains(name, ";") {
 		nameWithOpts := strings.Split(l[1], ";")
 		name = nameWithOpts[0]
 		for _, o := range nameWithOpts[1:] {
-			o := o
-			options[o] = struct{}{}
+			switch o {
+			case "emit_zero":
+				parsed.EmitZero = true
+			default:
+				log.Printf("[warn] unknown option %s in label %s", o, label)
+			}
 		}
 	}
-
+	parsed.Name = name
 	switch t {
 	case "service":
-		return &ParsedLabel{
-			Service: id,
-			Name:    name,
-			Options: options,
-		}, nil
+		parsed.Service = id
 	case "host":
-		return &ParsedLabel{
-			HostID:  id,
-			Name:    name,
-			Options: options,
-		}, nil
+		parsed.HostID = id
+	default:
+		return Label{}, fmt.Errorf("unknown label type %s", t)
 	}
-	return nil, errors.New("invalid label format")
+	return parsed, nil
 }
 
 func validateOption(opt *Option) (err error) {
@@ -114,27 +130,29 @@ func RunWithContext(ctx context.Context, opt Option) error {
 	if err := json.Unmarshal(opt.Query, &qs); err != nil {
 		return errors.Wrap(err, "failed to parse query as MetricDataQuery")
 	}
-
-	serviceMetrics, hostMetrics, err := fetchMetrics(ctx, opt, qs)
+	log.Printf("[debug] query %#v", qs)
+	results, err := fetchMetrics(ctx, opt, qs)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch metrics from CloudWatch")
 	}
+	log.Printf("[debug] results %#v", results)
+	serviceMetrics, hostMetrics := buildMetrics(results)
+	log.Printf("[debug] service metrics %#v", serviceMetrics)
+	log.Printf("[debug] host metrics %#v", hostMetrics)
 
 	postMetrics(ctx, opt, serviceMetrics, hostMetrics)
 	return nil
 }
 
-func fetchMetrics(ctx context.Context, opt Option, qs []*cloudwatch.MetricDataQuery) (map[string][]*mackerel.MetricValue, []*mackerel.HostMetricValue, error) {
+func fetchMetrics(ctx context.Context, opt Option, qs []*cloudwatch.MetricDataQuery) (map[Label]*cloudwatch.MetricDataResult, error) {
 	svc := cloudwatch.New(opt.Session)
-
-	serviceMetrics := make(map[string][]*mackerel.MetricValue)
-	hostMetrics := []*mackerel.HostMetricValue{}
 	var nextToken *string
-	results := make(map[string]*cloudwatch.MetricDataResult)
+	results := make(map[Label]*cloudwatch.MetricDataResult)
 	for {
 		if nextToken != nil {
 			log.Printf("[debug] GetMetricData nextToken:%s", *nextToken)
 		}
+		log.Printf("[debug] GetMetricData from %s to %s", opt.StartTime, opt.EndTime)
 		res, err := svc.GetMetricDataWithContext(
 			ctx,
 			&cloudwatch.GetMetricDataInput{
@@ -145,12 +163,16 @@ func fetchMetrics(ctx context.Context, opt Option, qs []*cloudwatch.MetricDataQu
 			},
 		)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to GetMetricData")
+			return nil, errors.Wrap(err, "failed to GetMetricData")
 		}
 
 		for _, r := range res.MetricDataResults {
 			result := r
-			label := *result.Label
+			label, err := parseLabel(*result.Label)
+			if err != nil {
+				log.Printf("[warn] %s label:%s", err, label)
+				continue
+			}
 			results[label] = result
 		}
 		if res.NextToken == nil {
@@ -159,47 +181,68 @@ func fetchMetrics(ctx context.Context, opt Option, qs []*cloudwatch.MetricDataQu
 		}
 		nextToken = res.NextToken
 	}
-
 	for _, query := range qs {
-		label := *query.Label
-		p, err := parseLabel(label)
+		label, err := parseLabel(*query.Label)
 		if err != nil {
 			log.Printf("[warn] %s label:%s", err, label)
 			continue
 		}
-		r, ok := results[label]
-		if !ok {
-			// data points not found
-			if _, ok := p.Options["emit_zero"]; ok {
-				r = &cloudwatch.MetricDataResult{
-					Timestamps: []*time.Time{&opt.EndTime},
-					Values:     []*float64{aws.Float64(0)},
-				}
+		var period time.Duration
+		if query.MetricStat.Period != nil {
+			period = time.Duration(*query.MetricStat.Period) * time.Second
+		} else if query.Period != nil {
+			period = time.Duration(*query.Period) * time.Second
+		}
+		if res, ok := results[label]; ok && label.EmitZero && period > 0 {
+			fillResult(opt, label, period, res)
+		}
+	}
+	return results, nil
+}
+
+func fillResult(opt Option, label Label, period time.Duration, res *cloudwatch.MetricDataResult) {
+	log.Printf("[debug] filling missing data points for %s (period %s)", label, period)
+TIMESTAMP:
+	for t := opt.StartTime.Truncate(time.Minute); t.Before(opt.EndTime); t = t.Add(period) {
+		ts := t
+		for _, v := range res.Timestamps {
+			if v.Equal(ts) {
+				continue TIMESTAMP
 			}
 		}
-		if r == nil {
-			continue
+		res.Timestamps = append(res.Timestamps, &ts)
+		res.Values = append(res.Values, aws.Float64(0))
+	}
+}
+
+func buildMetrics(results map[Label]*cloudwatch.MetricDataResult) (serviceMetrics map[string][]*mackerel.MetricValue, hostMetrics []*mackerel.HostMetricValue) {
+	serviceMetrics = make(map[string][]*mackerel.MetricValue)
+	hostMetrics = make([]*mackerel.HostMetricValue, 0)
+	for label, r := range results {
+		log.Printf("[debug] build metrics for %s", label)
+		if serviceMetrics[label.Service] == nil {
+			serviceMetrics[label.Service] = make([]*mackerel.MetricValue, 0)
 		}
 		for i, ts := range r.Timestamps {
 			tsUnix, value := (*ts).Unix(), *(r.Values[i])
 			mv := &mackerel.MetricValue{
-				Name:  p.Name,
+				Name:  label.Name,
 				Time:  tsUnix,
 				Value: value,
 			}
-			if p.Service != "" {
-				serviceMetrics[p.Service] = append(serviceMetrics[p.Service], mv)
-				log.Printf("[debug] service:%s metric:%v", p.Service, mv)
+			if label.IsService() {
+				serviceMetrics[label.Service] = append(serviceMetrics[label.Service], mv)
+				log.Printf("[debug] service:%s metric:%v", label.Service, mv)
 			} else {
 				hostMetrics = append(hostMetrics, &mackerel.HostMetricValue{
-					HostID:      p.HostID,
+					HostID:      label.HostID,
 					MetricValue: mv,
 				})
-				log.Printf("[debug] host:%s metric:%v", p.HostID, mv)
+				log.Printf("[debug] host:%s metric:%v", label.HostID, mv)
 			}
 		}
 	}
-	return serviceMetrics, hostMetrics, nil
+	return serviceMetrics, hostMetrics
 }
 
 func postMetrics(ctx context.Context, opt Option, serviceMetrics map[string][]*mackerel.MetricValue, hostMetrics []*mackerel.HostMetricValue) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,34 +8,30 @@ import (
 
 type labelSuite struct {
 	label  string
-	parsed *ParsedLabel
+	parsed Label
 }
 
 var labelSuites = []labelSuite{
 	{
 		label: "service=prod:foo.bar.baz",
-		parsed: &ParsedLabel{
+		parsed: Label{
 			Service: "prod",
 			Name:    "foo.bar.baz",
-			Options: map[string]struct{}{},
 		},
 	},
 	{
 		label: "host=abcdefg:boo.foo.uoo",
-		parsed: &ParsedLabel{
-			HostID:  "abcdefg",
-			Name:    "boo.foo.uoo",
-			Options: map[string]struct{}{},
+		parsed: Label{
+			HostID: "abcdefg",
+			Name:   "boo.foo.uoo",
 		},
 	},
 	{
 		label: "host=foo:hoge;emit_zero",
-		parsed: &ParsedLabel{
-			HostID: "foo",
-			Name:   "hoge",
-			Options: map[string]struct{}{
-				"emit_zero": {},
-			},
+		parsed: Label{
+			HostID:   "foo",
+			Name:     "hoge",
+			EmitZero: true,
 		},
 	},
 	{
@@ -52,9 +48,12 @@ var labelSuites = []labelSuite{
 func TestParseLabel(t *testing.T) {
 	for _, s := range labelSuites {
 		p, err := parseLabel(s.label)
-		if s.parsed != nil {
+		if s.parsed.Name != "" {
 			if diff := cmp.Diff(p, s.parsed); diff != "" {
 				t.Errorf("unexpected parseLine diff:%s", diff)
+			}
+			if s.label != p.String() {
+				t.Errorf("failed to roundtrip %s to %s", s.label, p.String())
 			}
 		} else {
 			if err == nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,20 +1,42 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 type labelSuite struct {
 	label  string
-	parsed *parsedLabel
+	parsed *ParsedLabel
 }
 
 var labelSuites = []labelSuite{
 	{
-		label:  "service=prod:foo.bar.baz",
-		parsed: &parsedLabel{service: "prod", name: "foo.bar.baz"},
+		label: "service=prod:foo.bar.baz",
+		parsed: &ParsedLabel{
+			Service: "prod",
+			Name:    "foo.bar.baz",
+			Options: map[string]struct{}{},
+		},
 	},
 	{
-		label:  "host=abcdefg:boo.foo.uoo",
-		parsed: &parsedLabel{hostID: "abcdefg", name: "boo.foo.uoo"},
+		label: "host=abcdefg:boo.foo.uoo",
+		parsed: &ParsedLabel{
+			HostID:  "abcdefg",
+			Name:    "boo.foo.uoo",
+			Options: map[string]struct{}{},
+		},
+	},
+	{
+		label: "host=foo:hoge;emit_zero",
+		parsed: &ParsedLabel{
+			HostID: "foo",
+			Name:   "hoge",
+			Options: map[string]struct{}{
+				"emit_zero": {},
+			},
+		},
 	},
 	{
 		label: "zzz:foo.bar.baz",
@@ -31,8 +53,8 @@ func TestParseLabel(t *testing.T) {
 	for _, s := range labelSuites {
 		p, err := parseLabel(s.label)
 		if s.parsed != nil {
-			if p.service != s.parsed.service || p.hostID != s.parsed.hostID || p.name != s.parsed.name {
-				t.Errorf("unexpected parseLine got:%#v expected:%#v", p, s.parsed)
+			if diff := cmp.Diff(p, s.parsed); diff != "" {
+				t.Errorf("unexpected parseLine diff:%s", diff)
 			}
 		} else {
 			if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.30.6
+	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mackerelio/mackerel-client-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/aws/aws-sdk-go v1.30.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
@@ -24,6 +26,8 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
Extend label syntax.

Introduce a label option `emit_zero` which enables to emit "0" value to Mackerel when data points are missing in CloudWatch.